### PR TITLE
stop bootstrap from hiding map overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
     <![endif]-->
 
   <!-- Latest compiled and minified CSS -->
-<!--  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">-->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 </head>
 <body>
+<!--  <header></header>-->
   <div id="map"></div>
   <h1>Hello</h1>
   <div class="btn-group" role="group" aria-label="...">
@@ -28,7 +29,7 @@
     <script type="text/javascript" src="http://mbostock.github.com/d3/d3.js?1.29.1"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
   <!-- Latest compiled and minified JavaScript -->
-<!--  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>-->
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -11,20 +11,20 @@ html, body, #map {
   padding: 0;
 }
 
-.stations, .stations svg {
+.stations {
   position: absolute;
-}
 
-.stations svg {
-  width: 60px;
-  height: 20px;
-  padding-right: 100px;
-  font: 10px sans-serif;
+  svg {
+    width: 60px;
+    height: 20px;
+    padding-right: 100px;
+    font: 10px sans-serif;
+    position: absolute;
+    box-sizing: content-box;
+  }
+  circle {
+    fill: brown;
+    stroke: black;
+    stroke-width: 1.5px;
+  }
 }
-
-.stations circle {
-  fill: brown;
-  stroke: black;
-  stroke-width: 1.5px;
-}
-


### PR DESCRIPTION
- add bootstrap back in
- nest .station(being used for cities) sass
- adjust svg box-sizing
